### PR TITLE
Fix wrong typo: hawOwn. Should've been hasOwn

### DIFF
--- a/lib/ReduxIE.js
+++ b/lib/ReduxIE.js
@@ -74,7 +74,7 @@ var _extends = Object.assign || function (target) {
 
   return target;
 };
-var hawOwn = Object.prototype.hasOwnProperty
+var hasOwn = Object.prototype.hasOwnProperty
 
 /**
  * @param {any} obj The object to inspect.


### PR DESCRIPTION
如题， fix #893